### PR TITLE
Add "group_by" and "remove" to functional

### DIFF
--- a/functional.lua
+++ b/functional.lua
@@ -263,4 +263,17 @@ function functional.find_match(t, f)
 	return nil
 end
 
+-- returns a table where the elements in t are grouped by the result of f on each element.
+function functional.group_by(t, f)
+	local result = {}
+	for i, v in ipairs(t) do
+		local group = f(v)
+		if result[group] == nil then
+			result[group] = {}
+		end
+		table.insert(result[group], v)
+	end
+	return result
+end
+
 return functional

--- a/functional.lua
+++ b/functional.lua
@@ -80,6 +80,17 @@ function functional.filter(t, f)
 	return r
 end
 
+-- inverse of filter - returns a table containing items where f(v) returns false.
+function functional.remove(t, f)
+	local r = {}
+	for i, v in ipairs(t) do
+		if not f(v, i) then
+			table.insert(r, v)
+		end
+	end
+	return r
+end
+
 --partitions a sequence based on filter criteria
 function functional.partition(t, f)
 	local a = {}


### PR DESCRIPTION
This PR adds four functions to `functional` and `tablex`:

In `tablex` it adds:
* `get` - equivalent to `tbl[x]` but allows you to set a context-relevant default.
* `get-in` which is similar, but is for nested tables:


```lua
 local get_example = { a = 1, b = 2, c = 3}
print(tablex.get(get_example, "a")) -- => "1"
print(tablex.get(get_example, "b")) -- => "2"
print(tablex.get(get_example, "d")) -- => "nil"
print(tablex.get(get_example, "d", "NOT_FOUND")) -- => "NOT_FOUND"

local get_in_example = {a = {b = {c = {d = "DONE"}}}}
print(tablex.get_in(get_in_example, {"x"}, "NOT_FOUND")) -- => "NOT_FOUND"
print(tablex.get_in(get_in_example, {"a", "b", "d" }, "NOT_FOUND")) -- => "NOT_FOUND"
print(tablex.get_in(get_in_example, {"a", "b", "c", "d"}, "NOT_FOUND")) -- => "DONE"
print(tablex.get_in(get_in_example, {"x"})) -- => "nil"
````

In `functional` it adds:

* `remove` which is just the complement to `filter`
* `group-by` which will return a table keyed by the return of the provided function:

```lua
local functional_example = {{alive = false}, {alive = false}, {alive = false}, {alive = false}, {alive = true}{alive = true}}

functional.group_by(functional_example, function(m) return m.alive end)

-- returns:
--- {true = {{alive = true}, {alive = true}}
---  false = {{alive = false}, {alive = false}, {alive = false}, {alive = false}}}

functional.remove(functional_example, function(m) return not m.alive end)

-- returns:
---- {{alive = true}, {alive = true}}
```

I was a little bored this morning, so I thought I'd add some of the functions I enjoy from my time with Clojure. I'm unsure if they fit with your idea of what `batteries` should be, so happy to be told to go add these somewhere else :)

(Also, sorry for the empty email, I accidentally mashed enter before ready)