### PR TITLE
Fixed `start` state inclusion in state_machine

### DIFF
--- a/state_machine.lua
+++ b/state_machine.lua
@@ -31,7 +31,7 @@ function state_machine:new(states, start)
 	self = self:init({
 		states = states or {},
 		current_state = "",
-		start_state = "",
+		start_state = start,
 	})
 
 	self:reset()


### PR DESCRIPTION
Fixed bug where `start` arg not used in state machine ctor