### PR TITLE
Added some extra methods to stringx

### DIFF
--- a/stringx.lua
+++ b/stringx.lua
@@ -216,31 +216,33 @@ function stringx.trim(s)
 end
 
 function stringx.ltrim(s)
-    if s == "" or s == string.rep(" ", s:len()) then return "" end
+	if s == "" or s == string.rep(" ", s:len()) then
+		return ""
+	end
 
-    local head = 1
-    for i = 1, #s do
-        local c = s:sub(i, i)
-        if c ~= " " then
-            head = i
-            break
-        end
-    end
-    return s:sub(head)
-
+	local head = 1
+	for i = 1, #s do
+		if not _whitespace_bytes[s:byte(i)] then
+			head = i
+			break
+		end
+	end
+	return s:sub(head)
 end
 
 function stringx.rtrim(s)
-    if s == "" or s == string.rep(" ", s:len()) then return "" end
-
-	local tail = #s
-	for i=#s, 1 do
-        local c = s:sub(i, i)
-        if c ~= " " then
-            tail = i
-            break
-        end
+	if s == "" or s == string.rep(" ", s:len()) then
+		return ""
 	end
+	local tail = #s
+
+	for i = #s, 1, -1 do
+		if not _whitespace_bytes[s:byte(i)] then
+			tail = i
+			break
+		end
+	end
+
 	return s:sub(1, tail)
 end
 

--- a/stringx.lua
+++ b/stringx.lua
@@ -320,4 +320,17 @@ function stringx.starts_with(s, prefix)
 	return true
 end
 
+function stringx.ends_with(s, prefix)
+	if prefix == "" then return true end
+
+	if #prefix > #s then return false end
+
+	for i = 0, #prefix-1 do
+		if s:byte(#s-i) ~= prefix:byte(#prefix-i) then
+			return false
+		end
+	end
+	return true
+end
+
 return stringx

--- a/stringx.lua
+++ b/stringx.lua
@@ -215,6 +215,35 @@ function stringx.trim(s)
 	return s:sub(head, tail)
 end
 
+function stringx.ltrim(s)
+    if s == "" or s == string.rep(" ", s:len()) then return "" end
+
+    local head = 1
+    for i = 1, #s do
+        local c = s:sub(i, i)
+        if c ~= " " then
+            head = i
+            break
+        end
+    end
+    return s:sub(head)
+
+end
+
+function stringx.rtrim(s)
+    if s == "" or s == string.rep(" ", s:len()) then return "" end
+
+	local tail = #s
+	for i=#s, 1 do
+        local c = s:sub(i, i)
+        if c ~= " " then
+            tail = i
+            break
+        end
+	end
+	return s:sub(1, tail)
+end
+
 function stringx.deindent(s, keep_trailing_empty)
 	--detect windows or unix newlines
 	local windows_newlines = s:find("\r\n", nil, true)

--- a/stringx.lua
+++ b/stringx.lua
@@ -320,13 +320,13 @@ function stringx.starts_with(s, prefix)
 	return true
 end
 
-function stringx.ends_with(s, prefix)
-	if prefix == "" then return true end
+function stringx.ends_with(s, posfix)
+	if posfix == "" then return true end
 
-	if #prefix > #s then return false end
+	if #posfix > #s then return false end
 
-	for i = 0, #prefix-1 do
-		if s:byte(#s-i) ~= prefix:byte(#prefix-i) then
+	for i = 0, #posfix-1 do
+		if s:byte(#s-i) ~= posfix:byte(#posfix-i) then
 			return false
 		end
 	end


### PR DESCRIPTION
Checking the _Todo/WIP list_, I saw that the `stringx` table needed some extensions. There are the methods that I've added;

* `ltrim`: similar to trim, but only trims the whitespaces at the left of the string
* `rtrim`: Idem to ltrim, but with the right whitespaces
* `ends_with`: similar to starts_with but it checks that the strings ends with the `posfix` given