### PR TITLE
Added min/max ops to vec2 and aabb_point_collide, aabb_circle_overlap/collide to intersect

### DIFF
--- a/intersect.lua
+++ b/intersect.lua
@@ -417,6 +417,17 @@ function intersect.aabb_aabb_collide_continuous(
 	return false
 end
 
+-- helper function to clamp point to aabb
+local _v_min = vec2:zero()
+local _v_max = vec2:zero()
+local _v_clamp = vec2:zero()
+local function aabb_clamp(pos, hs, v)
+	_v_min:sset(pos.x-hs.x, pos.y-hs.y)
+	_v_max:sset(pos.x+hs.x, pos.y+hs.y)
+	_v_clamp:vset(v):clampi(_v_min,_v_max)
+	return _v_clamp.x, _v_clamp.y
+end
+
 --check if a point is in a polygon
 --point is the point to test
 --poly is a list of points in order

--- a/intersect.lua
+++ b/intersect.lua
@@ -428,6 +428,15 @@ local function aabb_clamp(pos, hs, v)
 	return _v_clamp.x, _v_clamp.y
 end
 
+--  return true on overlap, false otherwise
+local _a_b_closest = vec2:zero()
+local _a_b_delta = vec2:zero() -- Delta vec for minimum distance between aabb and circle
+function intersect.aabb_circle_overlap(apos, ahs, bpos, brad)
+	_a_b_closest:sset(aabb_clamp(apos, ahs, bpos))
+	_a_b_delta:vset(bpos):vsubi(_a_b_closest)
+	return _a_b_delta:dot(_a_b_delta) < (brad*brad) + COLLIDE_EPS -- Pythag theorem
+end
+
 --check if a point is in a polygon
 --point is the point to test
 --poly is a list of points in order

--- a/intersect.lua
+++ b/intersect.lua
@@ -232,6 +232,26 @@ function intersect.aabb_point_overlap(pos, hs, v)
 	return _apo_delta.x < hs.x and _apo_delta.y < hs.y
 end
 
+-- discrete displacement
+-- return msv to push point to closest edge of aabb
+local _apo_delta_c = vec2:zero()
+local _apo_delta_c_abs = vec2:zero()
+local _apo_normal = vec2:zero()
+function intersect.aabb_point_collide(pos, hs, v, into)
+	_apo_delta_c:vset(v):vsubi(pos)
+	_apo_delta_c_abs:vset(_apo_delta_c):absi()
+	if _apo_delta_c_abs.x < hs.x and _apo_delta_c_abs.y < hs.y then
+		into = into or vec2:zero()
+		-- ahh get the point outta here
+		_apo_normal:vset(hs):vsubi(_apo_delta_c_abs):minori()
+		_apo_delta_c:vmuli(_apo_normal):normalisei():smuli(_apo_normal:length())
+		-- nudge it a bit
+		into:vset(_apo_delta_c):vaddi(_apo_delta_c:normalisei():smuli(COLLIDE_EPS))
+		return into
+	end
+	return false
+end
+
 --return true on overlap, false otherwise
 local _aao_abs_delta = vec2:zero()
 local _aao_total_size = vec2:zero()

--- a/vec2.lua
+++ b/vec2.lua
@@ -581,4 +581,57 @@ function vec2:apply_friction_xy(mu_x, mu_y, dt)
 	return self
 end
 
+-- mask out min component
+function vec2:majori()
+	if self.x > self.y then
+		self.y = 0
+	elseif self.x < self.y then
+		self.x = 0
+	end
+	return self
+end
+-- mask out max component
+function vec2:minori()
+	if self.x > self.y then
+		self.x = 0
+	elseif self.x < self.y then
+		self.y = 0
+	end
+	return self
+end
+-- max out min magnitude component
+function vec2:farthesti()
+	if math.abs(self.x) > math.abs(self.y) then
+		self.y = 0
+	elseif math.abs(self.x) < math.abs(self.y) then
+		self.x = 0
+	end
+	return self
+end
+-- max out max magnitude component
+function vec2:closesti()
+	if math.abs(self.x) > math.abs(self.y) then
+		self.x = 0
+	elseif math.abs(self.x) < math.abs(self.y) then
+		self.y = 0
+	end
+	return self
+end
+
+function vec2:major(axis)
+	return self:copy():majori(axis)
+end
+
+function vec2:minor(axis)
+	return self:copy():minori(axis)
+end
+
+function vec2:farthest(axis)
+	return self:copy():farthesti(axis)
+end
+
+function vec2:closest(axis)
+	return self:copy():closesti(axis)
+end
+
 return vec2


### PR DESCRIPTION
The separate files should probably be separate PR's (sorry)

For `vec2`, added the functions discussed (feel free to change the names). `major`/`minor` are min/max value component, `farthest`/`closest` are min/max magnitude component. `vec2:minori()` is used in `aabb_point_collide()`.

For `interesect`:

`aabb_point_collide` should be reviewed since it forces the point out if it's exactly on the aabb edge in a hacky-feeling way. Mainly, adding COLLIDE_EPS to the `hs` when calculating the msv direction (line 246)

`aabb_circle_overlap` is standard. However, I did add a helper function that it and collide both use (`aabb_clamp`). Feel free to refactor that out since it's conspicuously the only helper function in `intersect`.

`aabb_circle_collide` generates an msv in a few steps:
1. If circle pos inside aabb, get msv from `aabb_point_collide`
2. Get closest point on aabb to circle.
3. Get closest point on circle to 2.
4. Subtract 3. from 2. to get msv (`into:vaddi` called instead of `into:vset` in case 1. happened)

The major thing to review is whether a call to `intersect.aabb_point_overlap` is needed before running `_collide` (where there's a commented-out if-statement) since `aabb_point_collide` can modify `into` in-place. Although, I'm not intimate with lua enough to know if the return value is gc'd since it seems to be a reference to `input`. If it is, definitely uncomment the if-statement.

Hope my work is easy enough to correct :s