### PR TITLE
Fix shuffle to avoid bias

### DIFF
--- a/tablex.lua
+++ b/tablex.lua
@@ -173,7 +173,7 @@ end
 --shuffle the order of a table
 function tablex.shuffle(t, r)
 	for i = 1, #t do
-		local j = _random(1, #t, r)
+		local j = _random(i, #t, r)
 		t[i], t[j] = t[j], t[i]
 	end
 	return t


### PR DESCRIPTION
There's a subtle trick in shuffling: you should draw only from the part of the deck you have not seen!  Otherwise, some permutations are more common than others.