### PR TITLE
functional: fix generate_2d return value

### DIFF
--- a/functional.lua
+++ b/functional.lua
@@ -257,7 +257,7 @@ function functional.generate_2d(width, height, f)
 			end
 		end
 	end
-	return r
+	return result
 end
 
 -----------------------------------------------------------


### PR DESCRIPTION
`functional.generate_2d` returns `r`, but the value that should be returned is `result`.