### PR TITLE
functional: add splat

### DIFF
--- a/functional.lua
+++ b/functional.lua
@@ -64,12 +64,14 @@ function functional.map(t, f)
 end
 
 -- map a sequence (see functional.map)
--- the function must return an index and value to map appropriately
+-- the function may return an optional index
+-- if no index is provided, it will insert as normal
 function functional.splat(t, f)
 	local result = {}
 	for i = 1, #t do
 		local v, pos = f(t[i], i)
-		if v ~= nil and pos ~= nil then
+		if v ~= nil then
+			pos = (pos == nil and #result + 1) or pos
         	result[pos] = v
 		end
 	end

--- a/functional.lua
+++ b/functional.lua
@@ -63,6 +63,23 @@ function functional.map(t, f)
 	return result
 end
 
+-- map a sequence (see functional.map)
+-- when the function returns an index, map it there
+function functional.map_index(t, f)
+	local result = {}
+	for i = 1, #t do
+		local v, pos = f(t[i], i)
+		if v ~= nil then
+            if not pos then
+				table.insert(result, v)
+            else
+             	result[pos] = v
+            end
+		end
+	end
+	return result
+end
+
 --maps a sequence inplace, modifying it {a, b, c} -> {f(a), f(b), f(c)}
 -- (automatically drops any nils, which can be used to simultaneously map and filter)
 function functional.map_inplace(t, f)

--- a/functional.lua
+++ b/functional.lua
@@ -64,17 +64,13 @@ function functional.map(t, f)
 end
 
 -- map a sequence (see functional.map)
--- when the function returns an index, map it there
-function functional.map_index(t, f)
+-- the function must return an index and value to map appropriately
+function functional.splat(t, f)
 	local result = {}
 	for i = 1, #t do
 		local v, pos = f(t[i], i)
-		if v ~= nil then
-            if not pos then
-				table.insert(result, v)
-            else
-             	result[pos] = v
-            end
+		if v ~= nil and pos ~= nil then
+        	result[pos] = v
 		end
 	end
 	return result


### PR DESCRIPTION
Sometimes I want to map a table functionally via strings, but (as far as I can tell at least) this doesn't exist. I've added it as an alternative function to `map` called `map_index`. It will check if the index is being returned after the value (as long as a value is also returned). If there's no index, it simply maps normally with `table.insert`. Otherwise, the index returned is used.

Alternatively, I could have modified `map` to do this as well, but I wasn't sure if that was the best route. Let me know what you think.

(also apologies for not making this a separate branch, if that is necessary I will fix this)