### PR TITLE
Add luacheck and fix bugs it found

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,26 @@
+name: Linting
+
+on: [push, pull_request]
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        # Subdirectory to avoid linting luarocks code. Use same dir as testy.
+        path: batteries
+    - name: Setup Lua
+      uses: leafo/gh-actions-lua@v8
+      with:
+        luaVersion: 5.4
+    - name: Setup Lua Rocks
+      uses: leafo/gh-actions-luarocks@v4
+    - name: Setup luacheck
+      run: luarocks install luacheck
+    - name: Run Code Linter
+      run: |
+        cd batteries
+        luacheck .

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,7 +5,6 @@ return {
         "212", -- Unused argument.
         "212/self", -- Unused argument self.
         "213", -- Unused loop variable.
-        "231", -- Local variable is set but never accessed.
         "311", -- Value assigned to a local variable is unused.
         "631", -- Line is too long.
     },

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -4,7 +4,6 @@ return {
         "211", -- Unused local variable.
         "212/self", -- Unused argument self.
         "213", -- Unused loop variable.
-        "311", -- Value assigned to a local variable is unused.
         "631", -- Line is too long.
     },
     files = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,9 +15,6 @@ return {
         "423", -- Shadowing a loop variable.
         "423", -- Shadowing a loop variable.
         "432", -- Shadowing an upvalue argument.
-        "611", -- A line consists of nothing but whitespace.
-        "612", -- A line contains trailing whitespace.
-        "614", -- Trailing whitespace in a comment.
         "631", -- Line is too long.
     },
     files = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,46 @@
+return {
+    std = "lua51+love",
+    ignore = {
+        "143", -- Accessing an undefined field of a global variable.
+        "211", -- Unused local variable.
+        "212", -- Unused argument.
+        "212/self", -- Unused argument self.
+        "213", -- Unused loop variable.
+        "231", -- Local variable is set but never accessed.
+        "311", -- Value assigned to a local variable is unused.
+        "412", -- Redefining an argument.
+        "413", -- Redefining a loop variable.
+        "421", -- Shadowing a local variable.
+        "422", -- Shadowing an argument.
+        "423", -- Shadowing a loop variable.
+        "423", -- Shadowing a loop variable.
+        "432", -- Shadowing an upvalue argument.
+        "611", -- A line consists of nothing but whitespace.
+        "612", -- A line contains trailing whitespace.
+        "614", -- Trailing whitespace in a comment.
+        "631", -- Line is too long.
+    },
+    files = {
+        ["tests.lua"] = {
+            ignore = {
+                "211", -- Unused local variable. (testy will find these local functions)
+            },
+        },
+        ["assert.lua"] = {
+            ignore = {
+                "121", -- Setting a read-only global variable. (we clobber assert)
+            },
+        },
+        ["init.lua"] = {
+            ignore = {
+                "111", -- Setting an undefined global variable. (batteries and ripairs)
+                "121", -- Setting a read-only global variable. (we clobber assert)
+            },
+        },
+        ["sort.lua"] = {
+            ignore = {
+                "142", -- Setting an undefined field of a global variable. (inside export)
+            },
+        },
+    }
+}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,7 +2,6 @@ return {
     std = "lua51+love",
     ignore = {
         "211", -- Unused local variable.
-        "212", -- Unused argument.
         "212/self", -- Unused argument self.
         "213", -- Unused loop variable.
         "311", -- Value assigned to a local variable is unused.

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,7 +1,6 @@
 return {
     std = "lua51+love",
     ignore = {
-        "143", -- Accessing an undefined field of a global variable.
         "211", -- Unused local variable.
         "212", -- Unused argument.
         "212/self", -- Unused argument self.
@@ -25,6 +24,7 @@ return {
             ignore = {
                 "111", -- Setting an undefined global variable. (batteries and ripairs)
                 "121", -- Setting a read-only global variable. (we clobber assert)
+                "143", -- Accessing an undefined field of a global variable. (we use tablex as table)
             },
         },
         ["sort.lua"] = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,13 +8,6 @@ return {
         "213", -- Unused loop variable.
         "231", -- Local variable is set but never accessed.
         "311", -- Value assigned to a local variable is unused.
-        "412", -- Redefining an argument.
-        "413", -- Redefining a loop variable.
-        "421", -- Shadowing a local variable.
-        "422", -- Shadowing an argument.
-        "423", -- Shadowing a loop variable.
-        "423", -- Shadowing a loop variable.
-        "432", -- Shadowing an upvalue argument.
         "631", -- Line is too long.
     },
     files = {

--- a/assert.lua
+++ b/assert.lua
@@ -75,7 +75,7 @@ end
 
 --replace everything in assert with nop functions that just return their second argument, for near-zero overhead on release
 function assert:nop()
-	local nop = function(self, a)
+	local nop = function(_, a)
 		return a
 	end
 	setmetatable(self, {

--- a/async.lua
+++ b/async.lua
@@ -1,12 +1,12 @@
 --[[
 	simple kernel for async tasks running in the background
-	
+
 	can "stall" a task by yielding the string "stall"
 		this will suspend the coroutine until the rest of
 		the queue has been processed or stalled
 		and can early-out update_for_time
 
-	todo: 
+	todo:
 		multiple types of callbacks
 			finish, error, step
 		getting a reference to the task for manipulation

--- a/colour.lua
+++ b/colour.lua
@@ -136,7 +136,7 @@ function colour.rgb_to_hsl(r, g, b)
 	local l, d = max + min, max - min
 	local s = d / (l > 1 and (2 - l) or l)
 	l = l / 2
-	local h = nil --depends on below
+	local h --depends on below
 	if max == r then
 		h = (g - b) / d
 		if g < b then h = h + 6 end
@@ -145,6 +145,7 @@ function colour.rgb_to_hsl(r, g, b)
 	else
 		h = (r - g) / d + 4
 	end
+	assert(h)
 	return h / 6, s, l
 end
 

--- a/functional.lua
+++ b/functional.lua
@@ -209,7 +209,7 @@ end
 function functional.stitch(t, f)
 	local result = {}
 	for i, v in ipairs(t) do
-		local v = f(v, i)
+		v = f(v, i)
 		if v ~= nil then
 			if type(v) == "table" then
 				for _, e in ipairs(v) do

--- a/intersect.lua
+++ b/intersect.lua
@@ -186,7 +186,7 @@ function intersect.line_line_collide(a_start, a_end, a_rad, b_start, b_end, b_ra
 	local numerb = dx1 * dyab - dy1 * dxab
 
 	--check coincident lines
-	local intersected = "none"
+	local intersected
 	if
 		math.abs(numera) < COLLIDE_EPS and
 		math.abs(numerb) < COLLIDE_EPS and
@@ -215,6 +215,7 @@ function intersect.line_line_collide(a_start, a_end, a_rad, b_start, b_end, b_ra
 			end
 		end
 	end
+	assert(intersected)
 
 	if intersected == "both" then
 		--simply displace along A normal

--- a/intersect.lua
+++ b/intersect.lua
@@ -454,11 +454,11 @@ function intersect.point_aabb_collide(a, b_pos, b_hs, into)
 end
 
 function intersect.circle_aabb_overlap(a, a_rad, b_pos, b_hs)
-	return intersect.aabb_circle_overlap(b_pos, b_pos, a, a_rad)
+	return intersect.aabb_circle_overlap(b_pos, b_hs, a, a_rad)
 end
 
 function intersect.circle_aabb_collide(a, a_rad, b_pos, b_hs, into)
-	return intersect.reverse_msv(intersect.aabb_circle_collide(b_pos, b_pos, a, a_rad, into))
+	return intersect.reverse_msv(intersect.aabb_circle_collide(b_pos, b_hs, a, a_rad, into))
 end
 
 function intersect.circle_line_collide(a, a_rad, b_start, b_end, b_rad, into)

--- a/pretty.lua
+++ b/pretty.lua
@@ -153,7 +153,6 @@ function pretty._process(input, config, processing_state)
 			end
 			if break_next then
 				table.insert(line_chunks, table.remove(chunks, 1))
-				break_next = false
 			end
 		end
 		chunks = line_chunks

--- a/pretty.lua
+++ b/pretty.lua
@@ -60,7 +60,7 @@ function pretty._process(input, config, processing_state)
 
 	--pull out config
 	config = table.overlay({}, pretty.default_config, config or {})
-	
+
 	local per_line = config.per_line
 	local depth = config.depth
 	local indent = config.indent

--- a/set.lua
+++ b/set.lua
@@ -1,5 +1,8 @@
 --[[
 	set type with appropriate operations
+
+	NOTE: This is actually a unique list (ordered set). So it's more than just
+	a table with keys for values.
 ]]
 
 local path = (...):gsub("set", "")

--- a/sort.lua
+++ b/sort.lua
@@ -56,8 +56,8 @@ function sort._merge(array, workspace, low, middle, high, less)
 	local i, j, k
 	i = 1
 	-- copy first half of array to auxiliary array
-	for j = low, middle do
-		workspace[i] = array[j]
+	for w = low, middle do
+		workspace[i] = array[w]
 		i = i + 1
 	end
 	-- sieve through
@@ -78,8 +78,8 @@ function sort._merge(array, workspace, low, middle, high, less)
 		k = k + 1
 	end
 	-- copy back any remaining elements of first half
-	for k = k, j - 1 do
-		array[k] = workspace[i]
+	for w = k, j - 1 do
+		array[w] = workspace[i]
 		i = i + 1
 	end
 end
@@ -121,7 +121,8 @@ end
 
 function sort.stable_sort(array, less)
 	--setup
-	local trivial, n, less = sort._sort_setup(array, less)
+	local trivial, n
+	trivial, n, less = sort._sort_setup(array, less)
 	if not trivial then
 		--temp storage; allocate ahead of time
 		local workspace = {}
@@ -135,7 +136,8 @@ end
 
 function sort.insertion_sort(array, less)
 	--setup
-	local trivial, n, less = sort._sort_setup(array, less)
+	local trivial, n
+	trivial, n, less = sort._sort_setup(array, less)
 	if not trivial then
 		sort._insertion_sort_impl(array, 1, n, less)
 	end

--- a/state_machine.lua
+++ b/state_machine.lua
@@ -115,7 +115,7 @@ end
 --hard-replace a state table
 --	if we're replacing the current state,
 --	exit is called on the old state and enter is called on the new state
---	mask_transitions can be used to prevent this if you need to 
+--	mask_transitions can be used to prevent this if you need to
 function state_machine:replace_state(name, state, mask_transitions)
 	local do_transitions = not mask_transitions and self:in_state(name)
 	if do_transitions then

--- a/stringx.lua
+++ b/stringx.lua
@@ -249,6 +249,7 @@ end
 
 --check if a given string starts with another
 --(without garbage)
+--Using loops is actually faster than string.find!
 function stringx.starts_with(s, prefix)
 	for i = 1, #prefix do
 		if s:byte(i) ~= prefix:byte(i) then

--- a/stringx.lua
+++ b/stringx.lua
@@ -171,9 +171,7 @@ function stringx.deindent(s, keep_trailing_empty)
 	--split along newlines
 	local lines = stringx.split(s, newline)
 	--detect and strip any leading blank lines
-	local leading_newline = false
 	while lines[1] == "" do
-		leading_newline = true
 		table.remove(lines, 1)
 	end
 

--- a/tablex.lua
+++ b/tablex.lua
@@ -398,8 +398,8 @@ function tablex.collapse(t)
 	local r = {}
 	for _, v in ipairs(t) do
 		if type(v) == "table" then
-			for _, v in ipairs(v) do
-				table.insert(r, v)
+			for _, w in ipairs(v) do
+				table.insert(r, w)
 			end
 		else
 			table.insert(r, v)

--- a/tablex.lua
+++ b/tablex.lua
@@ -282,7 +282,7 @@ function tablex.append_inplace(t1, t2, ...)
 		table.insert(t1, v)
 	end
 	if ... then
-		return table.append_inplace(t1, ...)
+		return tablex.append_inplace(t1, ...)
 	end
 	return t1
 end

--- a/vec2.lua
+++ b/vec2.lua
@@ -266,7 +266,7 @@ end
 
 vec2.rot180_inplace = vec2.inverse_inplace --alias
 
---get the angle of this vector relative to (1, 0) 
+--get the angle of this vector relative to (1, 0)
 function vec2:angle()
 	return math.atan2(self.y, self.x)
 end

--- a/vec3.lua
+++ b/vec3.lua
@@ -343,7 +343,7 @@ local _euler_macro = {
 }
 function vec3:rotate_euleri(angle_x_axis, angle_y_axis, angle_z_axis)
 	for i, swizzle in ipairs(_euler_macro) do
-		local angle = 
+		local angle =
 			i == 1 and angle_x_axis
 			or i == 2 and angle_y_axis
 			or i == 3 and angle_z_axis


### PR DESCRIPTION
Setup a luacheck github action and configuration. Fix some legitimate bugs it discovered.

luacheck is pretty good at finding issues in lua code that a compiler would find in other languages. It has a lot of configuration options to control which warnings it emits. I've ignored a bunch of warnings and then added commits that fix the issues and remove those ignores. There are still a bunch of remaining warnings that are probably fine.

You can run it:

    luacheck .

You can see what the action output looks like:

* [Success](https://github.com/idbrii/love-batteries/runs/5411731898?check_suite_focus=true) (commit https://github.com/idbrii/love-batteries/commit/0c193d79019eb2d3fc25e7f0b5aa24197cb8b3ca has a little ✔️ )
* [Failure](https://github.com/idbrii/love-batteries/runs/5411990748?check_suite_focus=true) (commit: https://github.com/idbrii/love-batteries/commit/0d6076a3c8ebd3db6f29f0b87774064a9868b513 has a little ❌ )

With this PR, luacheck produces no warnings because any that occur are ignored in luacheckrc. (In each of these commits, luacheck runs clean because I'm only removing ignores that I fix.)

luacheck found two bugs: 

* crash when using append_inplace without batteries:export().
* circle_aabb_overlap wouldn't have the same results as
aabb_circle_overlap. (same for _collide)

