### PR TITLE
tablex: Add deep & shallow for copy, overlay; remove redundant recursion; add tests

### DIFF
--- a/.github/workflows/testy.yml
+++ b/.github/workflows/testy.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  testy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        # tests.lua expects top level folder to be 'batteries'
+        path: 'batteries'
+    - name: Setup Lua
+      uses: leafo/gh-actions-lua@v8
+      with:
+        luaVersion: 5.4
+    - name: Setup Lua Rocks
+      uses: leafo/gh-actions-luarocks@v4
+    - name: Setup testy
+      # Install from github because rock is 6+ years old.
+      run: luarocks install https://raw.githubusercontent.com/siffiejoe/lua-testy/master/testy-scm-0.rockspec
+    - name: Run tests
+      run: |
+        cd batteries
+        testy.lua tests.lua

--- a/init.lua
+++ b/init.lua
@@ -64,16 +64,16 @@ function _batteries:export()
 	end
 
 	--overlay tablex and functional and sort routines onto table
-	self.tablex.overlay(table, self.tablex)
+	self.tablex.shallow_overlay(table, self.tablex)
 	--now we can use it through table directly
-	table.overlay(table, self.functional)
+	table.shallow_overlay(table, self.functional)
 	self.sort:export()
 
 	--overlay onto global math table
-	table.overlay(math, self.mathx)
+	table.shallow_overlay(math, self.mathx)
 
 	--overlay onto string
-	table.overlay(string, self.stringx)
+	table.shallow_overlay(string, self.stringx)
 
 	--overwrite assert wholesale (it's compatible)
 	assert = self.assert

--- a/sequence.lua
+++ b/sequence.lua
@@ -44,8 +44,10 @@ for _, v in ipairs({
 	"dedupe",
 	"collapse",
 	"append",
-	"overlay",
-	"copy",
+	"shallow_overlay",
+	"deep_overlay",
+	"shallow_copy",
+	"deep_copy",
 }) do
 	local table_f = table[v]
 	sequence[v] = function(self, ...)

--- a/tablex.lua
+++ b/tablex.lua
@@ -329,41 +329,40 @@ if not tablex.clear then
 end
 
 -- Copy a table
---	See shallow_overlay to shallow copy into another table to avoid garbage.
+--	See shallow_overlay to shallow copy into an existing table to avoid garbage.
 function tablex.shallow_copy(t)
-	assert:type(t, "table", "tablex.copy - t", 1)
-	local into = {}
-	for k, v in pairs(t) do
-		into[k] = v
+	if type(t) == "table" then
+		local into = {}
+		for k, v in pairs(t) do
+			into[k] = v
+		end
+		return into
 	end
-	return into
+	return t
 end
 
 local function deep_copy(t, copied)
-	-- TODO: consider supporting deep_copy(3) so you can always use deep_copy without type checking
-	local into = {}
-	for k, v in pairs(t) do
-		local clone = v
-		if type(v) == "table" then
-			if copied[v] then
-				clone = copied[v]
-			elseif type(v.copy) == "function" then
-				clone = v:copy()
-				assert:type(clone, "table", "copy() didn't return a copy")
-			else
-				clone = deep_copy(v, copied)
-				setmetatable(clone, getmetatable(v))
+	local clone = t
+	if type(t) == "table" then
+		if copied[t] then
+			clone = copied[t]
+		elseif type(t.copy) == "function" then
+			clone = t:copy()
+			assert:type(clone, "table", "copy() didn't return a copy")
+		else
+			clone = {}
+			for k, v in pairs(t) do
+				clone[k] = deep_copy(v, copied)
 			end
-			copied[v] = clone
+			setmetatable(clone, getmetatable(t))
+			copied[t] = clone
 		end
-		into[k] = clone
 	end
-	return into
+	return clone
 end
 -- Recursively copy values of a table.
 -- Retains the same keys as original table -- they're not cloned.
 function tablex.deep_copy(t)
-	assert:type(t, "table", "tablex.deep_copy - t", 1)
 	return deep_copy(t, {})
 end
 

--- a/tablex.lua
+++ b/tablex.lua
@@ -417,8 +417,9 @@ function tablex.shallow_equal(a, b)
 			return false
 		end
 	end
+	-- second loop to ensure a isn't missing any keys from b.
 	for k, v in pairs(b) do
-		if a[k] ~= v then
+		if a[k] == nil then
 			return false
 		end
 	end
@@ -442,8 +443,10 @@ function tablex.deep_equal(a, b)
 			return false
 		end
 	end
+	-- second loop to ensure a isn't missing any keys from b, so we can skip
+	-- recursion.
 	for k, v in pairs(b) do
-		if not tablex.deep_equal(v, a[k]) then
+		if a[k] == nil then
 			return false
 		end
 	end

--- a/tests.lua
+++ b/tests.lua
@@ -1,0 +1,45 @@
+-- Run this file with testy:
+--	  testy.lua tests.lua
+-- testy sets `...` to "module.test", so ignore that and use module top-level paths.
+package.path = package.path .. ";../?.lua"
+
+local assert = require("batteries.assert")
+local tablex = require("batteries.tablex")
+
+
+-- tablex {{{
+
+local function test_shallow_equal()
+	local x,y
+	x = { a = { b = { 2 }, } }
+	y = { a = { b = { 2 }, } }
+	assert(not tablex.shallow_equal(x, y))
+
+	x = { 3, 4, "hello", [20] = "end", }
+	y = { 3, 4, "hello", [20] = "end", }
+	assert(tablex.shallow_equal(x, y))
+
+	local z = { 1, 2, }
+	x = { a = z, b = 10, c = true, }
+	y = { a = z, b = 10, c = true, }
+	assert(tablex.shallow_equal(x, y))
+	assert(tablex.shallow_equal(y, x))
+end
+
+local function test_deep_equal()
+	local x,y
+	x = { a = { b = { 2 }, c = { 3 }, } }
+	y = { a = { b = { 2 }, c = { 3 }, } }
+	assert(tablex.deep_equal(x, y))
+
+	x = { a = { b = { 1, 2 }, c = { 3 }, } }
+	y = { a = { c = { 3 }, b = { [2] = 2, [1] = 1 }, } }
+	assert(tablex.deep_equal(x, y))
+	assert(tablex.deep_equal(y, x))
+
+	x = { a = { b = { 2 }, c = { 3 }, 2 } }
+	y = { a = { b = { 2 }, c = { 3 }, } }
+	assert(not tablex.deep_equal(x, y))
+	assert(not tablex.deep_equal(y, x))
+end
+

--- a/tests.lua
+++ b/tests.lua
@@ -9,6 +9,79 @@ local tablex = require("batteries.tablex")
 
 -- tablex {{{
 
+local function test_shallow_copy()
+	local x,r
+	x = { a = 1, b = 2, c = 3 }
+	r = tablex.shallow_copy(x)
+	assert:equal(r.a, 1)
+	assert:equal(r.b, 2)
+	assert:equal(r.c, 3)
+
+	x = { a = { b = { 2 }, c = { 3 }, } }
+	r = tablex.shallow_copy(x)
+	assert:equal(r.a, x.a)
+end
+
+local function test_deep_copy()
+	local x,r
+	x = { a = 1, b = 2, c = 3 }
+	r = tablex.deep_copy(x)
+	assert:equal(r.a, 1)
+	assert:equal(r.b, 2)
+	assert:equal(r.c, 3)
+
+	x = { a = { b = { 2 }, c = { 3 }, } }
+	r = tablex.deep_copy(x)
+	assert(r.a ~= x.a)
+	assert:equal(r.a.b[1], 2)
+	assert:equal(r.a.c[1], 3)
+end
+
+
+local function test_shallow_overlay()
+	local x,y,r
+	x = { a = 1, b = 2, c = 3 }
+	y = { c = 8, d = 9 }
+	r = tablex.shallow_overlay(x, y)
+	assert(
+		tablex.deep_equal(
+			r,
+			{ a = 1, b = 2, c = 8, d = 9 }
+			)
+		)
+
+	x = { b = { 2 }, c = { 3 }, }
+	y = { c = { 8 }, d = { 9 }, }
+	r = tablex.shallow_overlay(x, y)
+	assert(r.b == x.b)
+	assert(r.c == y.c)
+	assert(r.d == y.d)
+	assert(
+		tablex.deep_equal(
+			r,
+			{ b = { 2 }, c = { 8 }, d = { 9 }, }))
+end
+
+local function test_deep_overlay()
+	local x,y,r
+	x = { a = 1, b = 2, c = 3 }
+	y = { c = 8, d = 9 }
+	r = tablex.deep_overlay(x, y)
+	assert(
+		tablex.deep_equal(
+			r,
+			{ a = 1, b = 2, c = 8, d = 9 }))
+
+	x = { a = { b = { 2 }, c = { 3 }, } }
+	y = { a = { c = { 8 }, d = { 9 }, } }
+	r = tablex.deep_overlay(x, y)
+	assert(
+		tablex.deep_equal(
+			r,
+			{ a = { b = { 2 }, c = { 8 }, d = { 9 }, } }))
+end
+
+
 local function test_shallow_equal()
 	local x,y
 	x = { a = { b = { 2 }, } }

--- a/tests.lua
+++ b/tests.lua
@@ -20,6 +20,10 @@ local function test_shallow_copy()
 	x = { a = { b = { 2 }, c = { 3 }, } }
 	r = tablex.shallow_copy(x)
 	assert:equal(r.a, x.a)
+
+	x = 10
+	r = tablex.shallow_copy(x)
+	assert:equal(r, x)
 end
 
 local function test_deep_copy()
@@ -35,6 +39,10 @@ local function test_deep_copy()
 	assert(r.a ~= x.a)
 	assert:equal(r.a.b[1], 2)
 	assert:equal(r.a.c[1], 3)
+
+	x = 10
+	r = tablex.deep_copy(x)
+	assert:equal(r, x)
 end
 
 


### PR DESCRIPTION
# Remove redundant recursion
Remove recursion from second loop of deep_equals. The first loop already checked for equality so the second only needs to check if the keys are there. Add test to validate.

# Add deep & shallow for copy, overlay

**BREAKING** Implement the comment over copy():
* Replace copy with shallow_copy, deep_copy.
  *  These copy functions copy any input type instead of requiring a table. That makes it easier to write generic code where you just want to copy some input without knowing anything about it. Like an event system, save system, etc.
* Replace overlay with shallow_overlay, deep_overlay.



# Add corresponding tests.

Tests can be run with [testy](https://github.com/siffiejoe/lua-testy) which is a low setup test framework -- it runs local functions prefixed with `test_` and uses `assert` to detect failures.

Add github action to run tests on PR. See test output:  [success](https://github.com/idbrii/love-batteries/runs/5424598856?check_suite_focus=true) on https://github.com/idbrii/love-batteries/commit/d48d4b0e816aeefdb49fd2c36da2b99028cf1887 [fail](https://github.com/idbrii/love-batteries/runs/5426732450?check_suite_focus=true) on https://github.com/idbrii/love-batteries/commit/d917e9648ee5c47bc4a876a630647d8e67e08e40. You can see that using vanilla assert() gives different output from batteries assert because testy provides a low-noise and non stopping 