### PR TITLE
async: Skip wrapping with xpcall under lovejs

### DIFF
--- a/assert.lua
+++ b/assert.lua
@@ -73,6 +73,15 @@ function assert:type(a, t, msg, stack_level)
 	return a
 end
 
+--assert a value is nil or a certain type.
+-- useful for optional parameters.
+function assert:type_or_nil(a, t, msg, stack_level)
+	if a ~= nil then
+		assert:type(a, t, msg, stack_level + 1)
+	end
+	return a
+end
+
 --replace everything in assert with nop functions that just return their second argument, for near-zero overhead on release
 function assert:nop()
 	local nop = function(self, a)

--- a/async.lua
+++ b/async.lua
@@ -16,6 +16,7 @@
 ]]
 
 local path = (...):gsub("async", "")
+local assert = require(path .. "assert")
 local class = require(path .. "class")
 
 local async = class({
@@ -51,6 +52,7 @@ end
 
 --add a task to the kernel
 function async:call(f, args, callback, error_callback)
+	assert:type_or_nil(args, "table", "async:call - args", 1)
 	f = capture_callstacks(f)
 	self:add(coroutine.create(f), args, callback, error_callback)
 end


### PR DESCRIPTION
Also reported here: https://github.com/Davidobot/love.js/issues/54.

lovejs crashes love with "attempt to yield across metamethod/C-call boundary" when you try to yield in a coroutine, so we skip wrapping. We lose the coroutine-local callstack, but at least it works.

Also, assert that args is a table and add assert:type_or_nil(). I hit this a couple times when switching from add_timeout() to call().
