### PR TITLE
string: add title_case

### DIFF
--- a/.test/tests.lua
+++ b/.test/tests.lua
@@ -6,6 +6,7 @@ package.path = package.path .. ";../?.lua"
 local assert = require("batteries.assert")
 local tablex = require("batteries.tablex")
 local identifier = require("batteries.identifier")
+local stringx = require("batteries.stringx")
 
 -- tablex {{{
 
@@ -195,4 +196,11 @@ local function test_ulid()
 		-- don't have characters out of crockford base32
 		assert(not ulid:match("[ILOU%l]"))
 	end
+end
+
+-- stringx
+local function test_title_case()
+    local str = "the quick brown fox jumps over the lazy dog"
+
+    assert(stringx.title_case(str) == "The Quick Brown Fox Jumps Over The Lazy Dog")
 end

--- a/stringx.lua
+++ b/stringx.lua
@@ -288,4 +288,13 @@ function stringx.split_and_trim(s, delim)
 	return s
 end
 
+--titlizes a string
+--"quick brown fox" becomes "Quick Brown Fox"
+function stringx.title_case(s)
+    s = s:gsub("%s%l", string.upper)
+    s = s:gsub("^%l", string.upper)
+
+    return s
+end
+
 return stringx


### PR DESCRIPTION
hello. I've added a Title Case function for strings. Haven't run the test case but it looks good 2 me :))

```lua
print(("hello max"):title_case()) -- Hello Max
print(("sphinx of black Quartz, judge My vow"):title_case()) -- Sphinx Of Black Quartz, Judge My Vow
```
