### PR TITLE
add `assert:one_of`

### DIFF
--- a/assert.lua
+++ b/assert.lua
@@ -10,7 +10,6 @@
 	can call nop() to dummy out everything for "release mode"
 	(if you're worried about that sort of thing)
 ]]
-
 local _assert = assert
 
 --proxy calls to global assert
@@ -79,6 +78,20 @@ function assert:type_or_nil(a, t, msg, stack_level)
 	if a ~= nil then
 		assert:type(a, t, msg, stack_level + 1)
 	end
+	return a
+end
+
+--assert a value is one of those in a table of options
+function assert:one_of(a, t, msg, stack_level)
+	local pass = false
+	for index = 1, #t do
+		if t[index] == a then
+			pass = true
+			break
+		end
+	end
+
+	assert:equal(pass, true, msg, stack_level)
 	return a
 end
 

--- a/assert.lua
+++ b/assert.lua
@@ -10,6 +10,7 @@
 	can call nop() to dummy out everything for "release mode"
 	(if you're worried about that sort of thing)
 ]]
+
 local _assert = assert
 
 --proxy calls to global assert

--- a/assert.lua
+++ b/assert.lua
@@ -84,16 +84,17 @@ end
 
 --assert a value is one of those in a table of options
 function assert:one_of(a, t, msg, stack_level)
-	local pass = false
-	for index = 1, #t do
-		if t[index] == a then
-			pass = true
-			break
+	for _, value in ipairs(t) do
+		if value == a then
+			return a
 		end
 	end
 
-	assert:equal(pass, true, msg, stack_level)
-	return a
+	error(("assertion failed: %s not one of %s %s"):format(
+		tostring(a),
+		table.concat(t, ", "),
+		_extra(msg)
+	), 2 + (stack_level or 0))
 end
 
 --replace everything in assert with nop functions that just return their second argument, for near-zero overhead on release


### PR DESCRIPTION
This was something I figured would be a nice-to-have while working on something. This asserts that, given a table, `t`, that value `a` is one of the items in the table. If it's not, then it will error. Granted this can be achieved with `functional` and `assert` together, but this allows for it to be done without the need of both modules.