### PR TITLE
vec2: add meta functions for mathematical operators

### DIFF
--- a/state_machine.lua
+++ b/state_machine.lua
@@ -33,6 +33,7 @@ local state_machine = class({
 function state_machine:new(states, start_in_state)
 	self.states = states or {}
 	self.current_state_name = ""
+	self.prev_state_name = ""
 	self.reset_state_name = start_in_state or ""
 	self:reset()
 end
@@ -151,6 +152,7 @@ end
 function state_machine:set_state(name, reset)
 	if self.current_state_name ~= name or reset then
 		self:_call("exit")
+		self.prev_state_name = self.current_state_name
 		self.current_state_name = name
 		self:_call_and_transition("enter", self)
 	end

--- a/state_machine.lua
+++ b/state_machine.lua
@@ -33,7 +33,6 @@ local state_machine = class({
 function state_machine:new(states, start_in_state)
 	self.states = states or {}
 	self.current_state_name = ""
-	self.prev_state_name = ""
 	self.reset_state_name = start_in_state or ""
 	self:reset()
 end
@@ -152,7 +151,6 @@ end
 function state_machine:set_state(name, reset)
 	if self.current_state_name ~= name or reset then
 		self:_call("exit")
-		self.prev_state_name = self.current_state_name
 		self.current_state_name = name
 		self:_call_and_transition("enter", self)
 	end

--- a/vec2.lua
+++ b/vec2.lua
@@ -455,25 +455,29 @@ end
 
 -- meta functions for mathmatical operations
 function vec2.__add(a, b)
-  return vec2(a.x + b.x, a.y + b.y)
+	return a:vector_add_inplace(b)
 end
 
 function vec2.__sub(a, b)
-  return vec2(a.x - b.x, a.y - b.y)
+	return a:vector_sub_inplace(b)
 end
 
 function vec2.__mul(a, b)
-  if type(a) == "number" then
-    return vec2(a * b.x, a * b.y)
-  elseif type(b) == "number" then
-    return vec2(a.x * b, a.y * b)
-  else
-    return vec2(a.x * b.x, a.y * b.y)
-  end
+	if type(a) == "number" then
+		return b:scalar_mul_inplace(a)
+	elseif type(b) == "number" then
+		return a:scalar_mul_inplace(b)
+	else
+		return a:vector_mul_inplace(b)
+	end
 end
 
 function vec2.__div(a, b)
-  return vec2(a.x / b, a.y / b)
+	if type(b) == "number" then
+		return a:scalar_div_inplace(b)
+	else
+		return a:vector_div_inplace(b)
+	end
 end
 
 -- mask out min component, with preference to keep x

--- a/vec2.lua
+++ b/vec2.lua
@@ -453,6 +453,29 @@ function vec2:maxcomp()
 	return math.max(self.x, self.y)
 end
 
+-- meta functions for mathmatical operations
+function vec2.__add(a, b)
+  return vec2(a.x + b.x, a.y + b.y)
+end
+
+function vec2.__sub(a, b)
+  return vec2(a.x - b.x, a.y - b.y)
+end
+
+function vec2.__mul(a, b)
+  if type(a) == "number" then
+    return vec2(a * b.x, a * b.y)
+  elseif type(b) == "number" then
+    return vec2(a.x * b, a.y * b)
+  else
+    return vec2(a.x * b.x, a.y * b.y)
+  end
+end
+
+function vec2.__div(a, b)
+  return vec2(a.x / b, a.y / b)
+end
+
 -- mask out min component, with preference to keep x
 function vec2:major_inplace()
 	if self.x > self.y then


### PR DESCRIPTION
As the title describes, this PR add's meta functions for mathematical operators.

addition:
`vec2(1, 2) + vec2(3, 4)` (4.00, 6.00)

subtraction:
`vec2(1, 2) - vec2(3, 4)` (-2.00, -2.00)

multiplication: 
`vec2(1, 2) * 2`  (2.00, 4.00)
`2 * vec2(3, 4)`  (6.00, 8.00)
`vec2(1, 2) * vec2(3, 4)` (3.00, 8.00)

division:
`vec2(4, 4) / 2`  (2.00, 2.00)


state_machine:
I added another field on the state_machine for the previous state name. This was a really small change and figured I would get input on that too while I'm here, though it probably should have been a separate PR... 

The use-case for me personally was using it to calculate unique behavior based on where we came from. For example I want to enter jump state from wallgrab state, but I want the velocity direction to be slightly tweaked in the jump state's update method if we came from wallgrab.

I find having these handy very useful and intuitive, let me know you're thoughts :)