### PR TITLE
state_machine: include prev_state_name

### DIFF
--- a/state_machine.lua
+++ b/state_machine.lua
@@ -33,7 +33,7 @@ local state_machine = class({
 function state_machine:new(states, start_in_state)
 	self.states = states or {}
 	self.current_state_name = ""
-  self.prev_state_name = ""
+	self.prev_state_name = ""
 	self.reset_state_name = start_in_state or ""
 	self:reset()
 end
@@ -88,7 +88,7 @@ end
 --add a state
 function state_machine:add_state(name, state)
 	if self:has_state(name) then
-		error("error: added duplicate state "..name)
+		error("error: added duplicate state " .. name)
 	else
 		self.states[name] = state
 		if self:in_state(name) then
@@ -102,7 +102,7 @@ end
 --remove a state
 function state_machine:remove_state(name)
 	if not self:has_state(name) then
-		error("error: removed missing state "..name)
+		error("error: removed missing state " .. name)
 	else
 		if self:in_state(name) then
 			self:_call("exit")
@@ -152,7 +152,7 @@ end
 function state_machine:set_state(name, reset)
 	if self.current_state_name ~= name or reset then
 		self:_call("exit")
-    self.prev_state_name = self.current_state_name
+		self.prev_state_name = self.current_state_name
 		self.current_state_name = name
 		self:_call_and_transition("enter", self)
 	end

--- a/state_machine.lua
+++ b/state_machine.lua
@@ -33,6 +33,7 @@ local state_machine = class({
 function state_machine:new(states, start_in_state)
 	self.states = states or {}
 	self.current_state_name = ""
+  self.prev_state_name = ""
 	self.reset_state_name = start_in_state or ""
 	self:reset()
 end
@@ -151,6 +152,7 @@ end
 function state_machine:set_state(name, reset)
 	if self.current_state_name ~= name or reset then
 		self:_call("exit")
+    self.prev_state_name = self.current_state_name
 		self.current_state_name = name
 		self:_call_and_transition("enter", self)
 	end


### PR DESCRIPTION
I just remade the branch

state_machine:
I added another field on the state_machine for the previous state name.

The use-case for me personally was using it to calculate unique behavior based on where we came from. For example I want to enter jump state from wallgrab state, but I want the velocity direction to be slightly tweaked in the jump state's update method if we came from wallgrab.

Let me know your thoughts!