### PR TITLE
Fix incorrect implementation of pingpong

### DIFF
--- a/mathx.lua
+++ b/mathx.lua
@@ -112,7 +112,7 @@ end
 
 --pingpong from 0 to 1 and back again
 function mathx.pingpong(f)
-	return 1 - math.abs(f - 0.5) * 2
+	return 1 - math.abs(1 - f % 2)
 end
 
 --quadratic ease in


### PR DESCRIPTION
Taken from [lume](https://github.com/rxi/lume/blob/master/lume.lua#L111).

Old:
```lua
print(mathx.pingpong(100)) -- -198
print(mathx.pingpong(101)) -- -200
```

New:
```lua
print(mathx.pingpong(100)) -- 0
print(mathx.pingpong(101)) -- 1
```
